### PR TITLE
Fix broken assertion in ParameterAssertionException

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Wikimedia\Assert;
 
 /**
@@ -52,14 +53,14 @@ class Assert {
 	 * negative impact on performance.
 	 *
 	 * @param bool $condition
-	 * @param string $argname The name of the parameter that was checked.
+	 * @param string $name The name of the parameter that was checked.
 	 * @param string $description The message to include in the exception if the condition fails.
 	 *
 	 * @throws ParameterAssertionException if $condition is not true.
 	 */
-	public static function parameter( $condition, $argname, $description ) {
+	public static function parameter( $condition, $name, $description ) {
 		if ( !$condition ) {
-			throw new ParameterAssertionException( $argname, $description );
+			throw new ParameterAssertionException( $name, $description );
 		}
 	}
 
@@ -78,14 +79,14 @@ class Assert {
 	 *        class or interface. If multiple types are allowed, they can be given separated by
 	 *        a pipe character ("|").
 	 * @param mixed $value The parameter's actual value.
-	 * @param string $argname The name of the parameter that was checked.
+	 * @param string $name The name of the parameter that was checked.
 	 *
 	 * @throws ParameterTypeException if $value is not of type (or, for objects, is not an
 	 *         instance of) $type.
 	 */
-	public static function parameterType( $type, $value, $argname ) {
+	public static function parameterType( $type, $value, $name ) {
 		if ( !self::hasType( $value, explode( '|', $type ) ) ) {
-			throw new ParameterTypeException( $argname, $type );
+			throw new ParameterTypeException( $name, $type );
 		}
 	}
 
@@ -102,20 +103,20 @@ class Assert {
 	 *        a pipe character ("|").
 	 * @param mixed $value The parameter's actual value. If this is not an array,
 	 *        a ParameterTypeException is raised.
-	 * @param string $argname The name of the parameter that was checked.
+	 * @param string $name The name of the parameter that was checked.
 	 *
 	 * @throws ParameterTypeException If $value is not an array.
 	 * @throws ParameterElementTypeException If an element of $value  is not of type
 	 *         (or, for objects, is not an instance of) $type.
 	 */
-	public static function parameterElementType( $type, $value, $argname ) {
-		$allowedTypes = explode( '|', $type );
+	public static function parameterElementType( $type, $value, $name ) {
+		self::parameterType( 'array', $value, $name );
 
-		self::parameterType( 'array', $value, $argname );
+		$allowedTypes = explode( '|', $type );
 
 		foreach ( $value as $element ) {
 			if ( !self::hasType( $element, $allowedTypes ) ) {
-				throw new ParameterElementTypeException( $argname, $type );
+				throw new ParameterElementTypeException( $name, $type );
 			}
 		}
 	}
@@ -166,6 +167,7 @@ class Assert {
 	 * @return bool
 	 */
 	private static function hasType( $value, array $allowedTypes ) {
+		// Apply strtolower because gettype returns "NULL" for null values.
 		$type = strtolower( gettype( $value ) );
 
 		if ( in_array( $type, $allowedTypes ) ) {
@@ -198,4 +200,5 @@ class Assert {
 
 		return false;
 	}
+
 }

--- a/src/AssertionException.php
+++ b/src/AssertionException.php
@@ -14,4 +14,3 @@ namespace Wikimedia\Assert;
 interface AssertionException {
 
 }
- 

--- a/src/InvariantException.php
+++ b/src/InvariantException.php
@@ -16,4 +16,3 @@ use LogicException;
 class InvariantException extends LogicException implements AssertionException {
 
 }
- 

--- a/src/ParameterAssertionException.php
+++ b/src/ParameterAssertionException.php
@@ -21,7 +21,7 @@ class ParameterAssertionException extends InvalidArgumentException implements As
 
 	/**
 	 * @param string $parameterName
-	 * @param int $description
+	 * @param string $description
 	 *
 	 * @throws ParameterTypeException
 	 */
@@ -30,7 +30,7 @@ class ParameterAssertionException extends InvalidArgumentException implements As
 			throw new ParameterTypeException( 'parameterName', 'string' );
 		}
 
-		if ( !is_string( $parameterName ) ) {
+		if ( !is_string( $description ) ) {
 			throw new ParameterTypeException( 'description', 'string' );
 		}
 
@@ -47,4 +47,3 @@ class ParameterAssertionException extends InvalidArgumentException implements As
 	}
 
 }
- 

--- a/src/ParameterElementTypeException.php
+++ b/src/ParameterElementTypeException.php
@@ -41,4 +41,3 @@ class ParameterElementTypeException extends ParameterAssertionException {
 	}
 
 }
- 

--- a/src/ParameterTypeException.php
+++ b/src/ParameterTypeException.php
@@ -41,4 +41,3 @@ class ParameterTypeException extends ParameterAssertionException {
 	}
 
 }
- 

--- a/src/PostconditionException.php
+++ b/src/PostconditionException.php
@@ -16,4 +16,3 @@ use LogicException;
 class PostconditionException extends LogicException implements AssertionException {
 
 }
- 

--- a/src/PreconditionException.php
+++ b/src/PreconditionException.php
@@ -15,4 +15,3 @@ use RuntimeException;
 class PreconditionException extends RuntimeException implements AssertionException {
 
 }
- 

--- a/tests/phpunit/AssertTest.php
+++ b/tests/phpunit/AssertTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Wikimedia\Assert\Test;
 
 use LogicException;


### PR DESCRIPTION
This patch:
- Fix actual bug in `ParameterAssertionException`.
- Switch execution order in `parameterElementType` for performance reasons.
- Simplify odd `$argname` variable name. It's called `$parameterName` in the exceptions. In methods that already have `parameter` in the name `$name` should be enough.
- Add a comment to the `strtolower` call.
- Fix newlines at the beginning and end of all files.
