### PR TITLE
Improve parameterType exception message by including the value

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -86,7 +86,7 @@ class Assert {
 	 */
 	public static function parameterType( $type, $value, $name ) {
 		if ( !self::hasType( $value, explode( '|', $type ) ) ) {
-			throw new ParameterTypeException( $name, $type );
+			throw new ParameterTypeException( $name, $type, $value );
 		}
 	}
 

--- a/src/ParameterAssertionException.php
+++ b/src/ParameterAssertionException.php
@@ -27,11 +27,11 @@ class ParameterAssertionException extends InvalidArgumentException implements As
 	 */
 	public function __construct( $parameterName, $description ) {
 		if ( !is_string( $parameterName ) ) {
-			throw new ParameterTypeException( 'parameterName', 'string' );
+			throw new ParameterTypeException( 'parameterName', 'string', $parameterName );
 		}
 
 		if ( !is_string( $description ) ) {
-			throw new ParameterTypeException( 'description', 'string' );
+			throw new ParameterTypeException( 'description', 'string', $description );
 		}
 
 		parent::__construct( "Bad value for parameter $parameterName: $description" );

--- a/src/ParameterElementTypeException.php
+++ b/src/ParameterElementTypeException.php
@@ -25,7 +25,7 @@ class ParameterElementTypeException extends ParameterAssertionException {
 	 */
 	public function __construct( $parameterName, $elementType ) {
 		if ( !is_string( $elementType ) ) {
-			throw new ParameterTypeException( 'elementType', 'string' );
+			throw new ParameterTypeException( 'elementType', 'string', $elementType );
 		}
 
 		parent::__construct( $parameterName, "all elements must be $elementType" );

--- a/src/ParameterTypeException.php
+++ b/src/ParameterTypeException.php
@@ -20,15 +20,17 @@ class ParameterTypeException extends ParameterAssertionException {
 	/**
 	 * @param string $parameterName
 	 * @param string $parameterType
+	 * @param mixed $parameterValue
 	 *
 	 * @throws ParameterTypeException
 	 */
-	public function __construct( $parameterName, $parameterType ) {
+	public function __construct( $parameterName, $parameterType, $parameterValue ) {
 		if ( !is_string( $parameterType ) ) {
-			throw new ParameterTypeException( 'parameterType', 'string' );
+			throw new ParameterTypeException( 'parameterType', 'string', $parameterType );
 		}
 
-		parent::__construct( $parameterName, "must be a $parameterType" );
+		$export = var_export( $parameterValue, true );
+		parent::__construct( $parameterName, "must be a $parameterType, got $export instead" );
 
 		$this->parameterType = $parameterType;
 	}

--- a/tests/phpunit/AssertTest.php
+++ b/tests/phpunit/AssertTest.php
@@ -115,7 +115,10 @@ class AssertTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testParameterType_catch() {
-		$this->setExpectedException( 'Wikimedia\Assert\AssertionException' );
+		$this->setExpectedException(
+			'Wikimedia\Assert\AssertionException',
+			'Bad value for parameter test: must be a string, got 17 instead'
+		);
 		Assert::parameterType( 'string', 17, 'test' );
 	}
 


### PR DESCRIPTION
Including the value with the wrong type makes it significantly easier to
debug issues.
